### PR TITLE
Corrected service name of 'dmwappushsvc' to 'dmwappushservice'

### DIFF
--- a/data-harvesting-services-removal.bat
+++ b/data-harvesting-services-removal.bat
@@ -8,9 +8,9 @@ REM Run it as an administrator from an elevated command prompt.
 REM It deletes services that Microsoft uses to harvest some of your data.
 
 net stop DiagTrack
-net stop dmwappushsvc
+net stop dmwappushservice
 net stop Wecsvc
-sc delete dmwappushsvc
+sc delete dmwappushservice
 sc delete diagtrack
 sc delete Wecsvc
 cd c:\ProgramData\Microsoft\Diagnosis\ETLLogs\Autologger


### PR DESCRIPTION
On my machine the service removal failed partly - a service name was wrong.