### PR TITLE
Update data-harvesting-services-removal.bat

### DIFF
--- a/data-harvesting-services-removal.bat
+++ b/data-harvesting-services-removal.bat
@@ -12,7 +12,6 @@ net stop dmwappushservice
 net stop Wecsvc
 sc delete dmwappushservice
 sc delete diagtrack
-sc delete Wecsvc
 cd c:\ProgramData\Microsoft\Diagnosis\ETLLogs\Autologger
 cacls Autologger-Diagtrack-Listener.etl /d SYSTEM
 


### PR DESCRIPTION
Maybe consider removing this as it makes it not easy recovering the service without copying another PC's registry entry for this service, completely removing it also has the effect of not providing critical error logs on driver BSOD etc. basically this makes the "Event Viewer" unfunctional and hard to recover this service without resetting the machine